### PR TITLE
FLUID-6324: fix Docpad version issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out/
 node_modules/
 src/files/lib
 .project
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -6,37 +6,39 @@ This is not an immediately deployable version of the website - [docpad](http://d
 
 # To Build Locally
 
-1. Install DocPad if it isn't already installed: `sudo npm install -g docpad`
-
-2. Get the required node modules: `npm install`
-
-3. Edit `docpad.coffee` URL value to reflect your target URL (with no trailing slash). The default value is `http://localhost:9778`. For local testing and development, you should keep this default value.
-
-4. Run docpad from the fluid-website directory `docpad run`.
-
-5. Open `http://localhost:9778/` to see the website. **Note**: you must access the site through the URL defined in `docpad.coffee` at Step 3, or you will see a CORS error when loading the icon fonts.
+1. Get the required node modules: `npm install`
+2. Edit `docpad.coffee` URL value to reflect your target URL (with no trailing slash). The default value is
+   `http://localhost:9778`. For local testing and development, you should keep this default value.
+3. Run docpad from the fluid-website directory `npm run docpad`.
+4. Open `http://localhost:9778/` to see the website. **Note**: you must access the site through the URL defined in
+   `docpad.coffee` at Step 2, or you will see a CORS error when loading the icon fonts.
 
 # To deploy to gh-pages:
 
-1. Start by working from a clone of the repository you want to deploy to. This step is important, otherwise your output may deploy to the wrong location.
-
-2. Change the ``url:`` value in the docpad.coffee to match your deployed gh-pages URL. If you intend to deploy to a custom domain, the URL value should match the target URL: `url: "www.example.com"`
-If deploying to gh-pages URL, the URL would look like this: `url: "username.github.io/fluidproject.org"`
-3. Deploy to gh-pages, run: `docpad deploy-ghpages --env static`. By doing this, docpad will generate the site to the remote gh-pages branch.
+1. Start by working from a clone of the repository you want to deploy to. This step is important, otherwise your output
+   may deploy to the wrong location.
+2. Change the url:` value in the docpad.coffee to match your deployed gh-pages URL. If you intend to deploy to a custom
+   domain, the URL value should match the target URL: `url: "www.example.com"`
+   If deploying to gh-pages URL, the URL would look like this: `url: "username.github.io/fluidproject.org"`
+3. Deploy to gh-pages, run: `npm run deploy`. By doing this, docpad will generate the site to the   
+   remote gh-pages branch.
 
 # To deploy to a personal webserver
 
-1. Change the ``url:`` value in the docpad.coffee to match your deployed URL.
-2. Run: ``` > docpad generate --env static ```
-3. Copy the contents of ```./out/``` directory to your server.
+1. Change the `url:` value in the docpad.coffee to match your deployed URL.
+2. Run: `npm run generate`
+3. Copy the contents of `./out/` directory to your server.
 
 ## Notes
 
-- Modifications can be done to any source file or directory except for the contents of the ``out/`` directory. The ``out`` directory and its contents are not to be versioned since it contains the generated output made by docpad from the source files and are overwritten.
-
-- The 404 error page will only appear when deployed to the *root* of a gh-pages domain or gh-pages custom domain. It will not appear when deployed locally or when deployed through a gh-pages (sub) project. To test the 404 error page, either load the 404.html directly in a browser, or deploy to the root of a gh-pages domain.
-
-- There are known issues regarding relative and absolute paths. See [FLUID-5588](http://issues.fluidproject.org/browse/FLUID-5588) and [FLUID-5570](http://issues.fluidproject.org/browse/FLUID-5590).
+- Modifications can be done to any source file or directory except for the contents of the `out/` directory. The `out`
+  directory and its contents are not to be versioned since it contains the generated output made by docpad from the
+  source files and are overwritten.
+- The 404 error page will only appear when deployed to the *root* of a gh-pages domain or gh-pages custom domain. It
+  will not appear when deployed locally or when deployed through a gh-pages (sub) project. To test the 404 error page,
+  either load the 404.html directly in a browser, or deploy to the root of a gh-pages domain.
+- There are known issues regarding relative and absolute paths. See
+  [FLUID-5588](http://issues.fluidproject.org/browse/FLUID-5588) and [FLUID-5570](http://issues.fluidproject.org/browse/FLUID-5590).
 
 
 ## Plugins used

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "node_modules/docpad/bin/docpad-server",
     "postinstall": "grunt",
-    "docpad": "node node_modules/docpad/bin/docpad run --env static --out out",
+    "docpad": "node node_modules/docpad/bin/docpad run",
     "deploy": "node node_modules/docpad/bin/docpad deploy-ghpages --env static",
     "generate": "node node_modules/docpad/bin/docpad generate --env static"
   }

--- a/package.json
+++ b/package.json
@@ -1,26 +1,23 @@
 {
-  "name": "no-skeleton.docpad",
+  "name": "fluidproject.org",
   "version": "0.1.0",
-  "description": "New DocPad project without using a skeleton",
-  "engines": {
-    "node": "0.10",
-    "npm": "1.3"
-  },
+  "description": "Fluid Project website",
   "dependencies": {
-    "docpad-plugin-eco": "~2.1.0",
-    "docpad-plugin-ghpages": "~2.4.4",
-    "docpad-plugin-handlebars": "~2.3.0",
-    "docpad-plugin-livereload": "~2.7.1",
-    "docpad-plugin-marked": "~2.3.0",
-    "docpad-plugin-moment": "~2.0.2",
-    "docpad-plugin-partials": "~2.9.2",
-    "docpad-plugin-redirector": "~2.0.3",
-    "docpad-plugin-stylus": "~2.11.0",
+    "docpad": "6.79.4",
+    "docpad-plugin-eco": "2.1.0",
+    "docpad-plugin-ghpages": "2.4.4",
+    "docpad-plugin-handlebars": "2.3.0",
+    "docpad-plugin-livereload": "2.7.1",
+    "docpad-plugin-marked": "2.3.0",
+    "docpad-plugin-moment": "2.0.2",
+    "docpad-plugin-partials": "2.9.2",
+    "docpad-plugin-redirector": "2.0.3",
+    "docpad-plugin-stylus": "2.11.0",
+    "foundation-sites": "5.5.3",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-copy": "1.0.0",
-    "infusion": "2.0.0",
-    "foundation-sites": "5.5.3"
+    "infusion": "2.0.0"
   },
   "devDependencies": {
     "eslint-config-fluid": "1.0.0",
@@ -30,6 +27,9 @@
   "main": "node_modules/docpad/bin/docpad-server",
   "scripts": {
     "start": "node_modules/docpad/bin/docpad-server",
-    "postinstall": "grunt"
+    "postinstall": "grunt",
+    "docpad": "node node_modules/docpad/bin/docpad run --env static --out out",
+    "deploy": "node node_modules/docpad/bin/docpad deploy-ghpages --env static",
+    "generate": "node node_modules/docpad/bin/docpad generate --env static"
   }
 }


### PR DESCRIPTION
Also does the following:
- pins dependency versions
- removes package-lock.json
- adds npm scripts for docpad build and deploy
- updates README

https://issues.fluidproject.org/browse/FLUID-6324