### PR TITLE
FLUID :- Fixed the upper line of rectangle colliding with the web icons

### DIFF
--- a/src/documents/css/style.css.styl
+++ b/src/documents/css/style.css.styl
@@ -213,7 +213,7 @@ body {
         height: 5rem;
         border-radius: 50rem;
         position: absolute;
-        top: -5rem;
+        top: -5.5rem;
         left: 1rem;
         font-family: 'fluid-community';
         font-size: 2.5rem;


### PR DESCRIPTION
This Pull Request solves the issue of upper line of the rectangle colliding with the fluid web community icons 
Fixed issue #22 
After :-
![Screenshot from 2020-02-28 23-40-13](https://user-images.githubusercontent.com/55639487/75573896-c88b2800-5a83-11ea-9cde-84673a1568c9.png)
.