### PR TITLE
FLUID-6461: fixed disappearing background picture of featured work on changing theme

### DIFF
--- a/src/documents/css/contrast.css.styl
+++ b/src/documents/css/contrast.css.styl
@@ -14,7 +14,6 @@ build-themes-extensions(contrastThemes) {
                     box-shadow: none;
                 }
                 .fluid-web-showcase-item {
-                    background: none !important;
                     border: 1px solid fColor;
                 }
                 a:hover,


### PR DESCRIPTION
fixes #28 
fixes #29
The images of featured work stay even when we change contrast or theme. 
Screenshots:
![Screenshot from 2020-03-04 05-45-44](https://user-images.githubusercontent.com/34926285/75832163-86dbe380-5ddb-11ea-8ca3-73248d09394c.png)
![Screenshot from 2020-03-04 05-46-28](https://user-images.githubusercontent.com/34926285/75832171-89d6d400-5ddb-11ea-806c-7ae3c144c60b.png)
 

