### PR TITLE
IRC made upper case

### DIFF
--- a/src/partials/community.html
+++ b/src/partials/community.html
@@ -3,7 +3,7 @@
     <div class="text-center fluid-web-community">
         <ul class="inline-list fluid-web-community-list">
             <li><a href="http://wiki.fluidproject.org/"><span class="fluid-web-community-icon fluid-web-community-wiki" role="presentation"></span>wiki</a></li>
-            <li><a href="http://wiki.fluidproject.org/display/fluid/IRC+Channel"><span class="fluid-web-community-icon fluid-web-community-irc" role="presentation"></span>irc chat</a></li>
+            <li><a href="http://wiki.fluidproject.org/display/fluid/IRC+Channel"><span class="fluid-web-community-icon fluid-web-community-irc" role="presentation"></span>IRC chat</a></li>
             <li><a href="http://issues.fluidproject.org"><span class="fluid-web-community-icon fluid-web-community-bugs" role="presentation"></span>bug tracking</a></li>
             <li><a href="http://github.com/fluid-project"><span class="fluid-web-community-icon fluid-web-community-source" role="presentation"></span>source code</a></li>
             <li><a href="http://wiki.fluidproject.org/display/fluid/Mailing+Lists"><span class="fluid-web-community-icon fluid-web-community-mailinglist" role="presentation"></span>mailing list</a></li>


### PR DESCRIPTION
IRC is an acronym and needs to be in capital letters. 