### PR TITLE
feat: temporarily redirect chinese users to google to counter DDoS from bots

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,6 +32,7 @@ module.exports = function(config) {
    config.addPassthroughCopy({"src/lib": "lib"});
    config.addPassthroughCopy({"src/assets/stylesheets": "assets/stylesheets"});
    config.addPassthroughCopy({"src/news/images": "news/images"})
+   config.addPassthroughCopy('_redirects');
 
   // Custom collections
   config.addCollection('news', collection => {

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/* https://google.com 302! Country=cn


### PR DESCRIPTION
Our bandwitdh usage from Netlify has skyrocketed in the past month. Upon analyzing the bandwidth usage (report provided by Netlify itself) and the Matomo analytics, it seems a lot of Chinese IPs are constantly accessing pages that don't exist and inflating our usage.

Unfortunately, more advanced blocking strategies are not available with Netlify and the suggested solution is to temporarily redirect all Chinese users to a different URL.

I say temporarily because I have some hope that, once we start redirecting them, the bots will give up since they will reach Google. I hate to deflect traffic to a 3rd-party in this way but I don't see another way to counter these bots.