### PR TITLE
feat: remove Netlify credit

### DIFF
--- a/src/_includes/partials/footer.html
+++ b/src/_includes/partials/footer.html
@@ -2,7 +2,6 @@
     <div class="medium-6 columns">
         <p>Fluid is a project of the <a href="http://idrc.ocadu.ca/">Inclusive Design Research Centre</a> at <a href="http://www.ocadu.ca">OCAD
 University</a>, funded by a grant from <a href="http://www.mellon.org/">The Andrew W. Mellon Foundation</a>.</p>
-        <p>Hosted with <a href="https://netlify.com/">Netlify</a>.</p>
 
         <address>
             The Inclusive Design Research Centre<br/>


### PR DESCRIPTION
Resolves #130. The site is now hosted on Cloudflare Pages which does not require a credit.